### PR TITLE
Ignoring server availability zone

### DIFF
--- a/templates/shared_services/gitea/terraform/mysql.tf
+++ b/templates/shared_services/gitea/terraform/mysql.tf
@@ -25,7 +25,12 @@ resource "azurerm_mysql_flexible_server" "gitea" {
     auto_grow_enabled = true
   }
 
-  lifecycle { ignore_changes = [tags] }
+  lifecycle { 
+    ignore_changes = [
+      tags,
+      zone
+    ] 
+  }
 }
 
 resource "azurerm_mysql_flexible_database" "gitea" {

--- a/templates/workspace_services/gitea/terraform/mysql.tf
+++ b/templates/workspace_services/gitea/terraform/mysql.tf
@@ -25,7 +25,12 @@ resource "azurerm_mysql_flexible_server" "gitea" {
     auto_grow_enabled = true
   }
 
-  lifecycle { ignore_changes = [tags] }
+  lifecycle {
+    ignore_changes = [
+      tags,
+      zone
+    ]
+  }
 }
 
 resource "azurerm_mysql_flexible_database" "gitea" {


### PR DESCRIPTION
# Resolves ignoring Availability Zone where MySQL Flexible Server is deployed

## What is being addressed

The zone is ignored so that during Gitea workspace/shared service updates no errors are reported.

## How is this addressed

- Adding `ignore_changes` tags in Terraform code
